### PR TITLE
Fixes bug during inital build with build-without-test.*

### DIFF
--- a/build-without-tests.bat
+++ b/build-without-tests.bat
@@ -4,13 +4,13 @@ if errorlevel 1 exit /B 1
 call mvn clean install -f command-bus
 if errorlevel 1 exit /B 1
 
+call mvn clean install -f policy-service-api
+if errorlevel 1 exit /B 1
+
 call mvn clean install -f documents-service-api
 if errorlevel 1 exit /B 1
 
 call mvn clean install -f payment-service-api
-if errorlevel 1 exit /B 1
-
-call mvn clean install -f policy-service-api
 if errorlevel 1 exit /B 1
 
 call mvn clean install -f policy-search-service-api
@@ -28,13 +28,13 @@ if errorlevel 1 exit /B 1
 call mvn clean install -f auth-service -Dmaven.test.skip
 if errorlevel 1 exit /B 1
 
+call mvn clean install -f policy-service -Dmaven.test.skip
+if errorlevel 1 exit /B 1
+
 call mvn clean install -f document-service -Dmaven.test.skip
 if errorlevel 1 exit /B 1
 
 call mvn clean install -f payment-service -Dmaven.test.skip
-if errorlevel 1 exit /B 1
-
-call mvn clean install -f policy-service -Dmaven.test.skip
 if errorlevel 1 exit /B 1
 
 call mvn clean install -f policy-search-service -Dmaven.test.skip

--- a/build-without-tests.sh
+++ b/build-without-tests.sh
@@ -4,13 +4,13 @@ mvn clean install -f command-bus-api
 mvn clean install -f command-bus
 [ $? -eq 0 ] || exit 1
 
+mvn clean install -f policy-service-api
+[ $? -eq 0 ] || exit 1
+
 mvn clean install -f documents-service-api
 [ $? -eq 0 ] || exit 1
 
 mvn clean install -f payment-service-api
-[ $? -eq 0 ] || exit 1
-
-mvn clean install -f policy-service-api
 [ $? -eq 0 ] || exit 1
 
 mvn clean install -f policy-search-service-api
@@ -25,13 +25,13 @@ mvn clean install -f product-service-api
 mvn clean install -f auth-service -Dmaven.test.skip
 [ $? -eq 0 ] || exit 1
 
+mvn clean install -f policy-service -Dmaven.test.skip
+[ $? -eq 0 ] || exit 1
+
 mvn clean install -f documents-service -Dmaven.test.skip
 [ $? -eq 0 ] || exit 1
 
 mvn clean install -f payment-service -Dmaven.test.skip
-[ $? -eq 0 ] || exit 1
-
-mvn clean install -f policy-service -Dmaven.test.skip
 [ $? -eq 0 ] || exit 1
 
 mvn clean install -f policy-search-service -Dmaven.test.skip


### PR DESCRIPTION
changes the build order of the following components:
document-service-api depends on policy-service-api
document-service depends on policy-service as test dependency