### PR TITLE
fix: Change ./dist into ./public for web-vue module

### DIFF
--- a/web-vue/Dockerfile
+++ b/web-vue/Dockerfile
@@ -5,7 +5,7 @@ ENV \
     GATEWAY_URL=${GATEWAY_URL:-http://localhost:8081} \
     AUTH_URL=${AUTH_URL:-http://localhost:8090}
 
-COPY ./dist /usr/share/nginx/html
+COPY ./public /usr/share/nginx/html
 
 COPY ./nginx-app.conf /etc/nginx/conf.d/default.tmpl
 


### PR DESCRIPTION
After executing:

sudo ./docker-build.sh 

I was receiving error:

ERROR: Service 'mn-web-vue' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder230422020/dist: no such file or directory

I have changed Dockerfile to resolve the issue